### PR TITLE
Bug: Files with syntax error

### DIFF
--- a/src/Padawan/Parser/Parser.php
+++ b/src/Padawan/Parser/Parser.php
@@ -60,7 +60,7 @@ class Parser {
                 $this->logger->error(sprintf("Parsing failed in file %s\n", $file));
                 $this->logger->error($e);
                 $this->clearWalkers();
-                return [];
+                return;
             }
             if ($createCache) {
                 $this->astPool[$file] = [$hash, $ast];


### PR DESCRIPTION
When files have syntax errors, parser should return nothing back
