### PR TITLE
В процессе сканирования файлов перехватывается Exception, чтобы общий…

### DIFF
--- a/src/Padawan/Framework/Generator/IndexGenerator.php
+++ b/src/Padawan/Framework/Generator/IndexGenerator.php
@@ -63,16 +63,20 @@ class IndexGenerator implements IndexGeneratorInterface
         $files = $this->filesFinder->findProjectFiles($project);
         $all = count($files);
         foreach ($files as $file) {
-            $start = microtime(1);
-            $this->processFile($index, $file, $rewrite);
-            $end = microtime(1) - $start;
+            try {
+                $start = microtime(1);
+                $this->processFile($index, $file, $rewrite);
+                $end = microtime(1) - $start;
 
-            $this->getLogger()->debug("Indexing: [$end]s");
-            $this->getLogger()->debug("Memory: " . memory_get_usage());
-            $globalTime += $end;
-            ++$done;
-            $process = floor($done / $all * 100);
-            $this->getLogger()->info("Progress: $process%");
+                $this->getLogger()->debug("Indexing: [$end]s");
+                $this->getLogger()->debug("Memory: " . memory_get_usage());
+                $globalTime += $end;
+                ++$done;
+                $process = floor($done / $all * 100);
+                $this->getLogger()->info("Progress: $process%");
+            } catch (Exception $e) {
+                $this->getLogger()->error(get_class($e).": ".$e->getMessage().". Trace: ".$e->getTraceAsString());
+            }
         }
         $this->getLogger()->info("[ $globalTime ]");
         gc_enable();

--- a/src/Padawan/Framework/Generator/IndexGenerator.php
+++ b/src/Padawan/Framework/Generator/IndexGenerator.php
@@ -76,6 +76,8 @@ class IndexGenerator implements IndexGeneratorInterface
                 $this->getLogger()->info("Progress: $process%");
             } catch (\Exception $e) {
                 $this->getLogger()->error(get_class($e).": ".$e->getMessage().". Trace: ".$e->getTraceAsString());
+            } catch (\Error $e) {
+                $this->getLogger()->error(get_class($e).": ".$e->getMessage().". Trace: ".$e->getTraceAsString());
             }
         }
         $this->getLogger()->info("[ $globalTime ]");

--- a/src/Padawan/Framework/Generator/IndexGenerator.php
+++ b/src/Padawan/Framework/Generator/IndexGenerator.php
@@ -74,7 +74,7 @@ class IndexGenerator implements IndexGeneratorInterface
                 ++$done;
                 $process = floor($done / $all * 100);
                 $this->getLogger()->info("Progress: $process%");
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 $this->getLogger()->error(get_class($e).": ".$e->getMessage().". Trace: ".$e->getTraceAsString());
             }
         }


### PR DESCRIPTION
… процесс не прерывался. Бывает, что сканирование проекта останавливается, например, когда в проекте присутствует symfony console с тест-классом NotLoadableClass.
