### PR TITLE
Add support for case "function as method params"

### DIFF
--- a/features/function-completion.feature
+++ b/features/function-completion.feature
@@ -1,0 +1,34 @@
+Feature: Function Completion
+    As a user
+    I want to have all functions when using functions' return value in argument list
+
+    Scenario: Getting all global functions with prefix
+        Given there is a file with:
+        """
+        <?php
+
+        function padawan_test_1(){}
+        function padawan_test_2(){}
+        function n_padawan_test_3(){}
+        function padawan_other(){}
+        """
+        When I type "$a = new DateTime(padawan_test" on the 7 line
+        And I ask for completion
+        Then I should get:
+            | Menu |
+            | padawan_test_1 |
+            | padawan_test_2 |
+
+    Scenario: Getting core functions with prefix
+        Given there is a file with:
+        """
+        <?php
+
+        function array_pop_custom(){}
+        """
+        When I type "$a = new DateTime(array_pop" on the 4 line
+        And I ask for completion
+        Then I should get:
+            | Menu |
+            | array_pop_custom |
+            | array_pop |


### PR DESCRIPTION
when completing `$a = new SomeClass(array_<TAB>`, `$context->getData()[3]` will be something like:

```
object(PhpParser\Node\Arg)#147063 (4) {
  ["value"]=>
  object(PhpParser\Node\Expr\ConstFetch)#148930 (2) {
    ["name"]=>
    object(PhpParser\Node\Name)#148360 (2) {
      ["parts"]=>
      array(1) {
        [0]=>
        string(6) "array_"
      }
      ["attributes":protected]=>
      array(2) {
        ["startLine"]=>
        int(1)
        ["endLine"]=>
        int(1)
      }
    }
    ["attributes":protected]=>
    array(2) {
      ["startLine"]=>
      int(1)
      ["endLine"]=>
      int(1)
    }
  }
  ["byRef"]=>
  bool(false)
  ["unpack"]=>
  bool(false)
  ["attributes":protected]=>
  array(2) {
    ["startLine"]=>
    int(1)
    ["endLine"]=>
    int(1)
  }
}
```

This PR adds support for situations like this.