### PR TITLE
Exclude test files from indexing.

### DIFF
--- a/specs/generator/filesfinder.spec.php
+++ b/specs/generator/filesfinder.spec.php
@@ -26,7 +26,6 @@ describe('FilesFinder', function() {
     describe('->findProjectFiles()', function() {
         it('returns all php files from project', function() {
             expect($this->files->findProjectFiles($this->project))->to->be->equal([
-                '/test/TestClass.php',
                 '/some/AnotherFile.php',
                 '/peridot.php'
             ]);

--- a/src/Padawan/Framework/Generator/FilesFinder.php
+++ b/src/Padawan/Framework/Generator/FilesFinder.php
@@ -35,6 +35,10 @@ class FilesFinder implements FilesFinderInterface
             if (!preg_match('/\.php$/', $file)) {
                 continue;
             }
+            if (preg_match('#/[tT]ests?/#', $file)) {
+                // exclude test files
+                continue;
+            }
             $projectFiles[] = $this->path->relative($project->getRootDir(), $file);
         }
         return $projectFiles;


### PR DESCRIPTION
May put this into command line argument, but now just use a default one.