### PR TITLE
Feature/support completing files with syntax error

### DIFF
--- a/bin/padawan-server
+++ b/bin/padawan-server
@@ -74,7 +74,7 @@ function runServer() {
         Co\await(function() use ($request, $response, $handler) {
             return $handler($request, $response);
         })->then(null, function($error) {
-            printf("Unhandled error: %s\n", $error->getMessage());
+            printf("Unhandled error: %s at %s:%s\n", $error->getMessage(), $error->getFile(), $error->getLine());
         });
     });
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "license": "MIT",
     "require": {
         "phine/path": "~1.0",
-        "nikic/php-parser": "2.1",
+        "nikic/php-parser": "~3.0",
         "monolog/monolog": "~1.13",
         "phpdocumentor/reflection-docblock": "~2.0",
         "symfony/event-dispatcher": "~2.6 || ~3.0",

--- a/src/Padawan/Command/CompleteCommand.php
+++ b/src/Padawan/Command/CompleteCommand.php
@@ -40,6 +40,8 @@ class CompleteCommand extends AsyncCommand
     }
     protected function executeAsync(InputInterface $input, HttpOutput $output)
     {
+        /** @var $logger \Psr\Log\LoggerInterface */
+        $logger = $this->getContainer()->get(\Psr\Log\LoggerInterface::class);
         $column = $input->getArgument("column");
         $file = $input->getArgument("filepath");
         $line = $input->getArgument("line");
@@ -52,6 +54,14 @@ class CompleteCommand extends AsyncCommand
         $completeEngine = $this->getContainer()->get(CompleteEngine::class);
         /** @var Persister */
         $persister = $this->getContainer()->get(Persister::class);
+
+        $logger->debug('Start completion', [
+            'line'   => $line,
+            'column' => $column,
+            'file'   => $file,
+            'path'   => $path
+        ]);
+
         try {
             $completion = $completeEngine->createCompletion(
                 $project,

--- a/src/Padawan/Domain/Scope/AbstractScope.php
+++ b/src/Padawan/Domain/Scope/AbstractScope.php
@@ -32,6 +32,10 @@ abstract class AbstractScope implements Scope
 
     public function addVar(Variable $var)
     {
+        if (array_key_exists($var->getName(), $this->variables)
+            && empty($var->getFQCN())) {
+            return;
+        }
         $this->variables[$var->getName()] = $var;
     }
 

--- a/src/Padawan/Parser/ErrorFreePhpParser.php
+++ b/src/Padawan/Parser/ErrorFreePhpParser.php
@@ -3,9 +3,10 @@
 namespace Padawan\Parser;
 
 use PhpParser\Parser\Php5 as ASTGenerator;
+use PhpParser\ErrorHandler;
 
 class ErrorFreePhpParser extends ASTGenerator {
-    public function parse($content) {
+    public function parse($content, ErrorHandler $errorHandler = NULL) {
         try {
             return parent::parse($content);
         }

--- a/src/Padawan/Parser/Parser.php
+++ b/src/Padawan/Parser/Parser.php
@@ -7,6 +7,7 @@ use Padawan\Domain\Project\Node\Uses;
 use Padawan\Framework\Utils\PathResolver;
 use PhpParser\ParserFactory;
 use PhpParser\NodeTraverser as Traverser;
+use PhpParser\ErrorHandler\Collecting;
 use Psr\Log\LoggerInterface;
 use Padawan\Parser\NamespaceParser;
 
@@ -35,12 +36,11 @@ class Parser
         }
         $this->setUses($uses);
         $this->setFileInfo($uses, $file);
-        try {
-            $parser = $this->parserFactory->create(ParserFactory::PREFER_PHP5);
-            $ast = $parser->parse($content);
-        } catch (\Exception $e) {
+        $parser = $this->parserFactory->create(ParserFactory::PREFER_PHP7, null);
+        $collector = new Collecting;
+        $ast = $parser->parse($content, $collector);
+        if (empty($ast)) {
             $this->logger->error(sprintf("Parsing failed in file %s\n", $file));
-            $this->logger->error($e);
             $this->clearWalkers();
             return;
         }

--- a/src/Padawan/Parser/Walker/ScopeWalker.php
+++ b/src/Padawan/Parser/Walker/ScopeWalker.php
@@ -16,7 +16,7 @@ use Padawan\Domain\Scope\FunctionScope;
 use Padawan\Domain\Scope\MethodScope;
 use Padawan\Domain\Scope\ClassScope;
 use Padawan\Domain\Scope\ClosureScope;
-use PhpParser\NodeTraverserInterface;
+use PhpParser\{NodeTraverser, NodeTraverserInterface};
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable as NodeVar;
@@ -47,7 +47,7 @@ class ScopeWalker extends NodeVisitorAbstract implements WalkerInterface
     {
         list($startLine, $endLine) = $this->getNodeLines($node);
         if (!$this->isIn($node, $this->line)) {
-            return NodeTraverserInterface::DONT_TRAVERSE_CHILDREN;
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
         }
         if ($node instanceof Class_) {
             $this->createScopeFromClass($node);


### PR DESCRIPTION
Write successfully parsed content into cache and use it when current file has semantic errors.

Useful when completing in situations like this:

```php
<?php
...
    if (some_expr() || $inst-><TAB>) {
    }
...
```