### PR TITLE
Add a lot of supports for parsing out types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: php
-php:
-    - '5.5'
-    - '5.6'
-    - '7.0'
+matrix:
+    include:
+      - php: '5.5'
+        env: BEHAT_TAGS=~@php70
+      - php: '5.6'
+        env: BEHAT_TAGS=~@php70
+      - php: '7.0'
+        env: BEHAT_TAGS=~@
 install:
     - composer install
-script: bin/peridot specs/ && bin/behat --colors
+script: bin/peridot specs/ && bin/behat --tags $BEHAT_TAGS --colors

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -132,7 +132,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
             }
             return $hash;
         }, $this->response["completion"]);
-        expect($table->getColumnsHash())->to->loosely->equal($result);
+        expect($result)->to->loosely->equal($table->getColumnsHash());
     }
 
     /** @var App */

--- a/features/closure.feature
+++ b/features/closure.feature
@@ -60,3 +60,146 @@ Feature: Completion in closure
             | test1     | Test1     |
             | test2     | Test2     |
             | test3     | array     |
+
+    Scenario: Getting closure argument in class method
+        Given there is a file with:
+        """
+        <?php
+
+        class Test1 {
+            public function foo() {
+                $a = function (Test1 $test1, Test2 $test2) {
+
+                };
+            }
+        }
+        """
+        When I type "$" on the 6 line
+        And I ask for completion
+        Then I should get:
+            | Name      | Signature |
+            | this      | Test1     |
+            | test1     | Test1     |
+            | test2     | Test2     |
+
+    Scenario: Getting closure uses in class method
+        Given there is a file with:
+        """
+        <?php
+
+        class Test1 {
+            public function foo() {
+                $test1 = new Test1();
+                $test2 = new Test2();
+                $test3 = [1,2,3,4];
+                $a = function (Test1 $test1, Test2 $test2) use ($test1, $test2, &$test3) {
+
+                };
+            }
+        }
+        """
+        When I type "$" on the 9 line
+        And I ask for completion
+        Then I should get:
+            | Name      | Signature |
+            | this      | Test1     |
+            | test1     | Test1     |
+            | test2     | Test2     |
+            | test3     | array     |
+
+    Scenario: Getting closure uses in class method
+        Given there is a file with:
+        """
+        <?php
+
+        class Test1 {
+            public function foo() {
+                $test1 = new Test1();
+                $test2 = new Test2();
+                $test3 = [1,2,3,4];
+                $a = function (Argument1 $arg1, Argument2 $arg2) use ($test1, $test2, &$test3) {
+
+                };
+            }
+        }
+        """
+        When I type "$" on the 9 line
+        And I ask for completion
+        Then I should get:
+            | Name      | Signature |
+            | this      | Test1     |
+            | arg1      | Argument1 |
+            | arg2      | Argument2 |
+            | test1     | Test1     |
+            | test2     | Test2     |
+            | test3     | array     |
+
+    Scenario: Getting static closure argument in class method
+        Given there is a file with:
+        """
+        <?php
+
+        class Test1 {
+            public function foo() {
+                $a = static function (Test1 $test1, Test2 $test2) {
+
+                };
+            }
+        }
+        """
+        When I type "$" on the 6 line
+        And I ask for completion
+        Then I should get:
+            | Name      | Signature |
+            | test1     | Test1     |
+            | test2     | Test2     |
+
+    Scenario: Getting static closure uses in class method
+        Given there is a file with:
+        """
+        <?php
+
+        class Test1 {
+            public function foo() {
+                $test1 = new Test1();
+                $test2 = new Test2();
+                $test3 = [1,2,3,4];
+                $a = static function (Test1 $test1, Test2 $test2) use ($test1, $test2, &$test3) {
+
+                };
+            }
+        }
+        """
+        When I type "$" on the 9 line
+        And I ask for completion
+        Then I should get:
+            | Name      | Signature |
+            | test1     | Test1     |
+            | test2     | Test2     |
+            | test3     | array     |
+
+    Scenario: Getting static closure uses in class method
+        Given there is a file with:
+        """
+        <?php
+
+        class Test1 {
+            public function foo() {
+                $test1 = new Test1();
+                $test2 = new Test2();
+                $test3 = [1,2,3,4];
+                $a = static function (Argument1 $arg1, Argument2 $arg2) use ($test1, $test2, &$test3) {
+
+                };
+            }
+        }
+        """
+        When I type "$" on the 9 line
+        And I ask for completion
+        Then I should get:
+            | Name      | Signature |
+            | arg1      | Argument1 |
+            | arg2      | Argument2 |
+            | test1     | Test1     |
+            | test2     | Test2     |
+            | test3     | array     |

--- a/features/closure.feature
+++ b/features/closure.feature
@@ -37,7 +37,7 @@ Feature: Completion in closure
             | Name      | Signature |
             | test1     | Test1     |
             | test2     | Test2     |
-            | test3     |           |
+            | test3     | array     |
 
     Scenario: Getting closure uses
         Given there is a file with:
@@ -59,4 +59,4 @@ Feature: Completion in closure
             | arg2      | Argument2 |
             | test1     | Test1     |
             | test2     | Test2     |
-            | test3     |           |
+            | test3     | array     |

--- a/features/namespace.feature
+++ b/features/namespace.feature
@@ -1,0 +1,125 @@
+Feature: Namespace Completion
+    As a user
+    I want to have namespaced completions when in namespace
+
+    Scenario: Getting namespaced completions inside of it
+        Given there is a file with:
+        """
+        <?php
+
+        namespace Test\Test1;
+
+        class SomeClass
+        {
+            /**
+             * @return SomeClass[]
+             */
+            public static function test()
+            {
+                return [];
+            }
+        }
+
+        $test = SomeClass::test();
+
+        """
+        When I type "$" on the 17 line
+        And I ask for completion
+        Then I should get:
+            | Name | Signature              |
+            | test | Test\Test1\SomeClass[] |
+
+    Scenario: Getting namespaced completions out of it
+        Given there is a file with:
+        """
+        <?php
+
+        namespace Test\Test1
+        {
+            class SomeClass
+            {
+                /**
+                 * @return SomeClass[]
+                 */
+                public static function test()
+                {
+                    return [];
+                }
+            }
+        }
+
+        namespace
+        {
+            use Test\Test1;
+
+            $test = SomeClass::test();
+
+        }
+        """
+        When I type "$" on the 22 line
+        And I ask for completion
+        Then I should get:
+            | Name | Signature              |
+            | test | Test\Test1\SomeClass[] |
+
+    Scenario: Getting namespaced completions from alias
+        Given there is a file with:
+        """
+        <?php
+
+        namespace Test\Test1
+        {
+            class SomeClass
+            {
+                public static function test()
+                {
+                    return [];
+                }
+            }
+        }
+
+        namespace
+        {
+            use Test\Test1 as Test2;
+
+            /** @var Test2\SomeClass[] */
+            $test = [];
+
+        }
+        """
+        When I type "$" on the 20 line
+        And I ask for completion
+        Then I should get:
+            | Name | Signature              |
+            | test | Test\Test1\SomeClass[] |
+
+    Scenario: Getting unqualified-namespaced completions
+        Given there is a file with:
+        """
+        <?php
+
+        namespace Test\Test1
+        {
+            class SomeClass
+            {
+                public static function test()
+                {
+                    return [];
+                }
+            }
+        }
+
+        namespace
+        {
+            use Test as Test2;
+
+            /** @var Test2\Test1\SomeClass[] */
+            $test = [];
+
+        }
+        """
+        When I type "$" on the 20 line
+        And I ask for completion
+        Then I should get:
+            | Name | Signature              |
+            | test | Test\Test1\SomeClass[] |

--- a/features/parameters-completion.feature
+++ b/features/parameters-completion.feature
@@ -1,0 +1,90 @@
+Feature: Parameters Completion
+    As a user
+    I want to have all parameters completed when typing a T_VARIABLE
+
+    Scenario: Getting native parameter list from function
+        Given there is a file with:
+        """
+        <?php
+
+        function padawan_test($test1, string $test2, DateTime ...$test3)
+        {
+
+        }
+        """
+        When I type "$" on the 5 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature  |
+            | test1 |            |
+            | test2 | string     |
+            | test3 | DateTime[] |
+
+    Scenario: Getting phpdoc parameter list from function
+        Given there is a file with:
+        """
+        <?php
+
+        /**
+         * @param resource $test1
+         * @param string $test2
+         * @param DateTime[] $test3
+         */
+        function padawan_test($test1, $test2, ...$test3)
+        {
+
+        }
+        """
+        When I type "$" on the 10 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature  |
+            | test1 | resource   |
+            | test2 | string     |
+            | test3 | DateTime[] |
+
+    Scenario: Getting native parameter list from class method
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeClass
+        {
+            public function test(SomeClass $test1, array $test2)
+            {
+
+            }
+        }
+        """
+        When I type "$" on the 7 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature |
+            | this  | SomeClass |
+            | test1 | SomeClass |
+            | test2 | array     |
+
+    Scenario: Getting phpdoc parameter list from class method
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeClass
+        {
+            /**
+             * @param SomeClass $test1
+             * @param SomeClass[][] $test2
+             */
+            public function test(SomeClass $test1, $test2)
+            {
+
+            }
+        }
+        """
+        When I type "$" on the 11 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature     |
+            | this  | SomeClass     |
+            | test1 | SomeClass     |
+            | test2 | SomeClass[][] |

--- a/features/return-type-completion.feature
+++ b/features/return-type-completion.feature
@@ -1,0 +1,83 @@
+Feature: Return Type Completion
+    As a user
+    I want to have return types completed from function or method calls
+
+    @php70
+    Scenario: Getting native return type from function call
+        Given there is a file with:
+        """
+        <?php
+
+        function padawan_test(): array {}
+        $test = padawan_test();
+
+        """
+        When I type "$" on the 5 line
+        And I ask for completion
+        Then I should get:
+            | Name | Signature  |
+            | test | array      |
+
+    Scenario: Getting phpdoc return type from function call
+        Given there is a file with:
+        """
+        <?php
+
+        /**
+         * @return string[][]
+         */
+        function padawan_test() {}
+        $test = padawan_test();
+
+        """
+        When I type "$" on the 8 line
+        And I ask for completion
+        Then I should get:
+            | Name | Signature  |
+            | test | string[][] |
+
+    @php70
+    Scenario: Getting native return type from class method call
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeClass
+        {
+            public function test(): array
+            {
+                $test = $this->test();
+
+            }
+        }
+        """
+        When I type "$" on the 8 line
+        And I ask for completion
+        Then I should get:
+            | Name | Signature |
+            | this | SomeClass |
+            | test | array     |
+
+    Scenario: Getting phpdoc return type from class method call
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeClass
+        {
+            /**
+             * @return SomeClass[]
+             */
+            public function test()
+            {
+                $test = $this->test();
+
+            }
+        }
+        """
+        When I type "$" on the 11 line
+        And I ask for completion
+        Then I should get:
+            | Name | Signature   |
+            | this | SomeClass   |
+            | test | SomeClass[] |

--- a/features/variables-completion.feature
+++ b/features/variables-completion.feature
@@ -1,0 +1,240 @@
+Feature: Variables Completion
+    As a user
+    I want to have all variables completed when typing a T_VARIABLE
+
+    Scenario: Getting all variables from the result of cast
+        Given there is a file with:
+        """
+        <?php
+
+        $test1 = (array)0;
+        $test2 = (bool)0;
+        $test3 = (double)0;
+        $test4 = (int)0;
+        $test5 = (object)0;
+        $test6 = (string)0;
+
+        """
+        When I type "$" on the 9 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature |
+            | test1 | array     |
+            | test2 | bool      |
+            | test3 | float     |
+            | test4 | int       |
+            | test5 | object    |
+            | test6 | string    |
+
+    Scenario: Getting all variables from the result of literal values
+        Given there is a file with:
+        """
+        <?php
+
+        $test1 = array();
+        $test2 = [];
+        $test3 = true;
+        $test4 = false;
+        $test5 = 0.0;
+        $test6 = 0;
+        $test7 = '';
+        $test8 = "{$test7}";
+        $test9 = `ls -a`;
+
+        """
+        When I type "$" on the 12 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature |
+            | test1 | array     |
+            | test2 | array     |
+            | test3 | bool      |
+            | test4 | bool      |
+            | test5 | float     |
+            | test6 | int       |
+            | test7 | string    |
+            | test8 | string    |
+            | test9 | string    |
+
+    Scenario: Getting all variables from the result of operators
+        Given there is a file with:
+        """
+        <?php
+
+        $test1 = !!0;
+        $test2 = isset($test1);
+        $test3 = empty($test1);
+        $test4 = print '';
+
+        """
+        When I type "$" on the 7 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature |
+            | test1 | bool      |
+            | test2 | bool      |
+            | test3 | bool      |
+            | test4 | int       |
+
+    Scenario: Getting all variables from the result of magic constants
+        Given there is a file with:
+        """
+        <?php
+
+        $test1 = __LINE__;
+        $test2 = __FILE__;
+        $test3 = __DIR__;
+        $test4 = __FUNCTION__;
+        $test5 = __CLASS__;
+        $test6 = __TRAIT__;
+        $test7 = __METHOD__;
+        $test8 = __NAMESPACE__;
+
+        """
+        When I type "$" on the 11 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature |
+            | test1 | int       |
+            | test2 | string    |
+            | test3 | string    |
+            | test4 | string    |
+            | test5 | string    |
+            | test6 | string    |
+            | test7 | string    |
+            | test8 | string    |
+
+    Scenario: Getting all variables from the language structures
+        Given there is a file with:
+        """
+        <?php
+
+        $test1;
+        $test2 = new DateTime();
+        $test3 = clone $test2;
+        $test4 = $test2;
+        $test5 = $test3;
+        unset($test4, $test5);
+
+        """
+        When I type "$" on the 9 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature |
+            | test1 |           |
+            | test2 | DateTime  |
+            | test3 | DateTime  |
+
+    Scenario: Getting global variables inside a function
+        Given there is a file with:
+        """
+        <?php
+
+        $test = [];
+
+        function padawan_test() {
+
+        }
+        """
+        When I type "global $" on the 6 line
+        And I ask for completion
+        Then I should get:
+            | Name | Signature |
+            | test | array     |
+
+    Scenario: Getting global/static variables inside a function
+        Given there is a file with:
+        """
+        <?php
+
+        $test1 = [];
+        $test2 = [];
+        $test3 = [];
+
+        function padawan_test() {
+            global $test1, $test2;
+            static $test4 = 0;
+
+        }
+        """
+        When I type "$" on the 10 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature |
+            | test1 | array     |
+            | test2 | array     |
+            | test4 | int       |
+
+    Scenario: Getting a variable inside a list expression
+        Given there is a file with:
+        """
+        <?php
+
+        /** @var string[] */
+        $test1 = [];
+
+        list($test2, $test3) = $test1;
+        [$test4, $test5] = $test1;
+
+        /** @var string[][] */
+        $test6 = [];
+
+        list($test7, , list($test8)) = $test6;
+        [$test9, , [$test10]] = $test6;
+
+        """
+        When I type "$" on the 14 line
+        And I ask for completion
+        Then I should get:
+            | Name   | Signature  |
+            | test1  | string[]   |
+            | test2  | string     |
+            | test3  | string     |
+            | test4  | string     |
+            | test5  | string     |
+            | test6  | string[][] |
+            | test7  | string[]   |
+            | test8  | string     |
+            | test9  | string[]   |
+            | test10 | string     |
+
+    Scenario: Getting a variable inside a foreach statement
+        Given there is a file with:
+        """
+        <?php
+
+        /** @var string[][] */
+        $test1 = [];
+
+        foreach ($test1 as $test2) {
+            foreach ($test2 as list($test3, $test4)) {
+
+            }
+        }
+        """
+        When I type "$" on the 8 line
+        And I ask for completion
+        Then I should get:
+            | Name  | Signature  |
+            | test1 | string[][] |
+            | test2 | string[]   |
+            | test3 | string     |
+            | test4 | string     |
+
+    Scenario: Getting a variable inside a catch statement
+        Given there is a file with:
+        """
+        <?php
+
+        try {
+            throw new RuntimeException();
+        } catch (LogicException $e) {
+        } catch (RuntimeException $e) {
+
+        }
+        """
+        When I type "$" on the 7 line
+        And I ask for completion
+        Then I should get:
+            | Name | Signature        |
+            | e    | RuntimeException |

--- a/src/Padawan/Domain/Completer/CompleterFactory.php
+++ b/src/Padawan/Domain/Completer/CompleterFactory.php
@@ -21,6 +21,7 @@ class CompleterFactory
         UseCompleter $useCompleter,
         VarCompleter $varCompleter,
         GlobalFunctionsCompleter $functionsCompleter,
+        GlobalCompleter $globalCompleter,
         EventDispatcher $dispatcher
     ) {
         $this->completers = [
@@ -31,7 +32,8 @@ class CompleterFactory
             $staticCompleter,
             $useCompleter,
             $varCompleter,
-            $functionsCompleter
+            $functionsCompleter,
+            $globalCompleter,
         ];
         $this->dispatcher = $dispatcher;
     }

--- a/src/Padawan/Domain/Completer/GlobalCompleter.php
+++ b/src/Padawan/Domain/Completer/GlobalCompleter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Padawan\Domain\Completer;
+
+use Padawan\Domain\Completion\Context;
+use Padawan\Domain\Scope;
+use Padawan\Domain\Project;
+use Padawan\Domain\Project\Node\Variable;
+use Padawan\Domain\Completion\Entry;
+use Padawan\Domain\Project\FQCN;
+use Padawan\Domain\Scope\AbstractChildScope;
+
+class GlobalCompleter extends AbstractInCodeBodyCompleter
+{
+    public function getEntries(Project $project, Context $context)
+    {
+        $scope = $context->getScope();
+        do {
+            $scope = $scope->getParent();
+        } while ($scope instanceof AbstractChildScope);
+
+        return array_map([$this, 'createEntry'], $scope->getVars());
+    }
+
+    public function canHandle(Project $project, Context $context)
+    {
+        return parent::canHandle($project, $context) && $context->isGlobal();
+    }
+
+    protected function createEntry(Variable $var)
+    {
+        $type = $var->getType() instanceof FQCN ?
+            $var->getType()->toString() : $var->getType();
+        return new Entry(
+            $var->getName(),
+            $type
+        );
+    }
+}

--- a/src/Padawan/Domain/Completer/ObjectCompleter.php
+++ b/src/Padawan/Domain/Completer/ObjectCompleter.php
@@ -86,7 +86,7 @@ class ObjectCompleter extends AbstractInCodeBodyCompleter
     protected function createEntryForProperty(ClassProperty $prop)
     {
         if ($prop->type instanceof FQCN) {
-            $type = $prop->type->getClassName() . ($prop->type->isArray() ? '[]' : '');
+            $type = $prop->type->getClassName() . str_repeat('[]', $prop->type->getDimension());
         } else {
             $type = 'mixed';
         }

--- a/src/Padawan/Domain/Completer/ObjectCompleter.php
+++ b/src/Padawan/Domain/Completer/ObjectCompleter.php
@@ -85,7 +85,11 @@ class ObjectCompleter extends AbstractInCodeBodyCompleter
 
     protected function createEntryForProperty(ClassProperty $prop)
     {
-        $type = $prop->type instanceof FQCN ? $prop->type->getClassName() : 'mixed';
+        if ($prop->type instanceof FQCN) {
+            $type = $prop->type->getClassName() . ($prop->type->isArray() ? '[]' : '');
+        } else {
+            $type = 'mixed';
+        }
         return new Entry(
             $prop->name,
             $type

--- a/src/Padawan/Domain/Completion/Context.php
+++ b/src/Padawan/Domain/Completion/Context.php
@@ -17,6 +17,7 @@ class Context
     const T_METHOD_CALL      = 512;
     const T_VAR              = 1024;
     const T_ANY_NAME         = 2048;
+    const T_GLOBAL           = 4096;
 
     private $type            = 0;
     private $token;
@@ -30,24 +31,26 @@ class Context
     public function setToken(Token $token) {
         $this->token = $token;
         if ($token->isVar()) {
-            $this->addType(Context::T_VAR);
+            $this->addType(self::T_VAR);
+        } elseif ($token->isGlobal()) {
+            $this->addType(self::T_GLOBAL);
         } elseif ($token->isObjectOperator()) {
-            $this->addType(Context::T_OBJECT);
+            $this->addType(self::T_OBJECT);
         } elseif ($token->isStaticOperator()) {
-            $this->addType(Context::T_CLASS_STATIC);
+            $this->addType(self::T_CLASS_STATIC);
         } elseif ($token->isNamespaceOperator()) {
-            $this->addType(Context::T_NAMESPACE);
+            $this->addType(self::T_NAMESPACE);
         } elseif ($token->isUseOperator()) {
-            $this->addType(Context::T_USE);
-            $this->addType(Context::T_CLASSNAME);
+            $this->addType(self::T_USE);
+            $this->addType(self::T_CLASSNAME);
         } elseif ($token->isNewOperator()) {
-            $this->addType(Context::T_CLASSNAME);
+            $this->addType(self::T_CLASSNAME);
         } elseif ($token->isExtendsOperator()) {
-            $this->addType(Context::T_CLASSNAME);
+            $this->addType(self::T_CLASSNAME);
         } elseif ($token->isImplementsOperator()) {
-            $this->addType(Context::T_INTERFACENAME);
+            $this->addType(self::T_INTERFACENAME);
         } elseif ($token->isMethodCall()) {
-            $this->addType(Context::T_METHOD_CALL);
+            $this->addType(self::T_METHOD_CALL);
         } elseif ($token->isString()) {
             $this->addType(self::T_ANY_NAME);
             $this->setData($token->getSymbol());
@@ -84,6 +87,9 @@ class Context
     }
     public function isVar() {
         return (bool) ($this->type & self::T_VAR);
+    }
+    public function isGlobal() {
+        return (bool) ($this->type & self::T_GLOBAL);
     }
     public function isUse() {
         return (bool) ($this->type & self::T_USE);

--- a/src/Padawan/Domain/Completion/Token.php
+++ b/src/Padawan/Domain/Completion/Token.php
@@ -42,9 +42,11 @@ class Token
         case T_GLOBAL:
         case T_EXTENDS:
         case T_IMPLEMENTS:
-        case '$':
         case '(':
             $this->resetType(self::$MAP[$code]);
+            break;
+        case '$':
+            $this->resetType(self::T_VAR | self::T_CONTINUE_PROCESS);
             break;
         case ';':
         case ',':
@@ -210,7 +212,6 @@ class Token
         T_EXTENDS               => Token::T_EXTENDS_OPERATOR,
         T_IMPLEMENTS            => Token::T_IMPLEMENTS_OPERATOR,
         T_GLOBAL                => Token::T_GLOBAL,
-        '$'                     => Token::T_VAR | Token::T_CONTINUE_PROCESS,
         '('                     => Token::T_METHOD_CALL
     ];
 

--- a/src/Padawan/Domain/Completion/Token.php
+++ b/src/Padawan/Domain/Completion/Token.php
@@ -39,6 +39,7 @@ class Token
         case T_NAMESPACE:
         case T_USE:
         case T_NEW:
+        case T_GLOBAL:
         case T_EXTENDS:
         case T_IMPLEMENTS:
         case '$':
@@ -127,6 +128,11 @@ class Token
         return (bool) ($this->type & self::T_VAR);
     }
 
+    public function isGlobal()
+    {
+        return (bool) ($this->type & self::T_GLOBAL);
+    }
+
     public function isWhitespace()
     {
         return (bool) ($this->type & self::T_WHITESPACE);
@@ -192,6 +198,7 @@ class Token
     const T_METHOD_CALL         = 2048;
     const T_STRING              = 4096;
     const T_EMPTY               = 8192;
+    const T_GLOBAL              = 16384;
 
     protected static $MAP = [
         T_VARIABLE              => Token::T_VAR,
@@ -202,7 +209,8 @@ class Token
         T_NEW                   => Token::T_NEW_OPERATOR,
         T_EXTENDS               => Token::T_EXTENDS_OPERATOR,
         T_IMPLEMENTS            => Token::T_IMPLEMENTS_OPERATOR,
-        '$'                     => Token::T_VAR,
+        T_GLOBAL                => Token::T_GLOBAL,
+        '$'                     => Token::T_VAR | Token::T_CONTINUE_PROCESS,
         '('                     => Token::T_METHOD_CALL
     ];
 

--- a/src/Padawan/Domain/Project/FQCN.php
+++ b/src/Padawan/Domain/Project/FQCN.php
@@ -12,9 +12,9 @@ class FQCN extends FQN {
             return $this->getNamespace();
         }
     }
-    public function __construct($className, $namespace = "", $isArray = false) {
+    public function __construct($className, $namespace = "", $dimension = 0) {
         parent::__construct($namespace);
-        $this->_isArray = $isArray;
+        $this->_dimension = (int)$dimension;
         $this->_isScalar = false;
         if (count($this->parts) === 0) {
             switch ($className) {
@@ -57,20 +57,20 @@ class FQCN extends FQN {
         array_pop($parts);
         return implode("\\", $parts);
     }
+    public function getDimension() {
+        return $this->_dimension ?: (int)$this->_isArray;
+    }
     public function toString() {
-        $str = parent::toString();
-        if ($this->isArray()) {
-            $str .= '[]';
-        }
-        return $str;
+        return parent::toString() . str_repeat('[]', $this->_dimension);
     }
     public function isArray() {
-        return $this->_isArray;
+        return $this->_dimension > 0 || $this->_isArray;
     }
     public function isScalar() {
         return $this->_isScalar;
     }
 
+    private $_dimension;
     private $_isArray;
     private $_isScalar;
 }

--- a/src/Padawan/Domain/Project/Node/FunctionData.php
+++ b/src/Padawan/Domain/Project/Node/FunctionData.php
@@ -59,7 +59,7 @@ class FunctionData
     public function getReturnStr()
     {
         if ($this->return instanceof FQCN) {
-            return $this->return->getClassName();
+            return $this->return->getClassName() . ($this->return->isArray() ? '[]' : '');
         }
         return "mixed";
     }

--- a/src/Padawan/Domain/Project/Node/FunctionData.php
+++ b/src/Padawan/Domain/Project/Node/FunctionData.php
@@ -46,7 +46,7 @@ class FunctionData
             $curParam = [];
             if ($argument->getType()) {
                 if ($argument->getType() instanceof FQCN) {
-                    $curParam[] = $argument->getType()->getClassName();
+                    $curParam[] = $argument->getType()->getClassName() . str_repeat('[]', $argument->getType()->getDimension());
                 } else {
                     $curParam[] = $argument->getType();
                 }
@@ -59,7 +59,7 @@ class FunctionData
     public function getReturnStr()
     {
         if ($this->return instanceof FQCN) {
-            return $this->return->getClassName() . ($this->return->isArray() ? '[]' : '');
+            return $this->return->getClassName() . str_repeat('[]', $this->return->getDimension());
         }
         return "mixed";
     }

--- a/src/Padawan/Domain/Scope/AbstractScope.php
+++ b/src/Padawan/Domain/Scope/AbstractScope.php
@@ -35,6 +35,14 @@ abstract class AbstractScope implements Scope
         $this->variables[$var->getName()] = $var;
     }
 
+    public function removeVar(Variable $var)
+    {
+        $name = array_search($var, $this->variables);
+        if ($name !== false) {
+            unset($this->variables[$name]);
+        }
+    }
+
     public function getFunctions()
     {
         return $this->functions;

--- a/src/Padawan/Domain/Scope/ClosureScope.php
+++ b/src/Padawan/Domain/Scope/ClosureScope.php
@@ -2,9 +2,23 @@
 
 namespace Padawan\Domain\Scope;
 
-use Padawan\Domain\Project\Node\FunctionData;
+use Padawan\Domain\Project\Node\ClassData;
 use Padawan\Domain\Scope;
+use Padawan\Domain\Project\Node\Variable;
 
 class ClosureScope extends AbstractChildScope
 {
+    /**
+     * @param Scope $scope
+     * @param ClassData $class
+     */
+    public function __construct(Scope $scope, $class = null)
+    {
+        parent::__construct($scope);
+        if ($class !== null) {
+            $var = new Variable('this');
+            $var->setType($class->fqcn);
+            $this->addVar($var);
+        }
+    }
 }

--- a/src/Padawan/Framework/Complete/Resolver/NodeTypeResolver.php
+++ b/src/Padawan/Framework/Complete/Resolver/NodeTypeResolver.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Isset_;
@@ -74,6 +75,9 @@ class NodeTypeResolver
         }
         if ($node instanceof New_ && $node->class instanceof Name) {
             return $this->useParser->getFQCN($node->class);
+        }
+        if ($node instanceof Closure) {
+            return new FQCN('Closure');
         }
         if ($node instanceof Cast\Bool_
             || $node instanceof BooleanNot

--- a/src/Padawan/Framework/Complete/Resolver/NodeTypeResolver.php
+++ b/src/Padawan/Framework/Complete/Resolver/NodeTypeResolver.php
@@ -18,6 +18,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Clone_;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\Print_;
@@ -75,6 +76,9 @@ class NodeTypeResolver
         }
         if ($node instanceof New_ && $node->class instanceof Name) {
             return $this->useParser->getFQCN($node->class);
+        }
+        if ($node instanceof Clone_) {
+            return $this->getType($node->expr, $index, $scope);
         }
         if ($node instanceof Closure) {
             return new FQCN('Closure');

--- a/src/Padawan/Framework/Complete/Resolver/NodeTypeResolver.php
+++ b/src/Padawan/Framework/Complete/Resolver/NodeTypeResolver.php
@@ -10,13 +10,27 @@ use Padawan\Domain\Scope;
 use Padawan\Parser\UseParser;
 use PhpParser\Node\Name;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\Isset_;
+use PhpParser\Node\Expr\Print_;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Empty_;
+use PhpParser\Node\Expr\ShellExec;
+use PhpParser\Node\Expr\Cast;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Scalar\Encapsed;
+use PhpParser\Node\Scalar\MagicConst;
+use PhpParser\Node\Scalar\MagicConst\Line;
+use PhpParser\Node\Scalar\DNumber;
+use PhpParser\Node\Scalar\LNumber;
 use Psr\Log\LoggerInterface;
 use Padawan\Domain\Project\Chain;
 use Padawan\Domain\Project\Chain\MethodCall as ChainMethodCall;
@@ -52,12 +66,50 @@ class NodeTypeResolver
         if ($node instanceof Variable
             || $node instanceof PropertyFetch
             || $node instanceof StaticPropertyFetch
+            || $node instanceof FuncCall
             || $node instanceof MethodCall
             || $node instanceof StaticCall
         ) {
             return $this->getLastChainNodeType($node, $index, $scope);
-        } elseif ($node instanceof New_ && $node->class instanceof Name) {
+        }
+        if ($node instanceof New_ && $node->class instanceof Name) {
             return $this->useParser->getFQCN($node->class);
+        }
+        if ($node instanceof Cast\Bool_
+            || $node instanceof BooleanNot
+            || $node instanceof Isset_
+            || $node instanceof Empty_
+            || ($node instanceof ConstFetch && in_array(strtolower($node->name), ['true', 'false']))
+        ) {
+            return new FQCN('bool');
+        }
+        if ($node instanceof Cast\Array_
+            || $node instanceof Array_
+        ) {
+            return new FQCN('array');
+        }
+        if ($node instanceof Cast\Object_) {
+            return new FQCN('object');
+        }
+        if ($node instanceof Cast\Double
+            || $node instanceof DNumber
+        ) {
+            return new FQCN('float');
+        }
+        if ($node instanceof Cast\Int_
+            || $node instanceof LNumber
+            || $node instanceof Line
+            || $node instanceof Print_
+        ) {
+            return new FQCN('int');
+        }
+        if ($node instanceof Cast\String_
+            || $node instanceof String_
+            || $node instanceof Encapsed
+            || $node instanceof MagicConst
+            || $node instanceof ShellExec
+        ) {
+            return new FQCN('string');
         }
         return null;
     }
@@ -131,7 +183,12 @@ class NodeTypeResolver
                 }
             } elseif ($block->getType() === 'function') {
                 $name = $block->getName();
-                $function = $index->findFunctionByName($name->toString());
+                if ($name instanceof Name) {
+                    $name = $name->toString();
+                } elseif ($name instanceof Variable) {
+                    $name = $name->name;
+                }
+                $function = $index->findFunctionByName($name);
                 if (empty($function)) {
                     $type = null;
                 } else {

--- a/src/Padawan/Framework/Complete/Resolver/NodeTypeResolver.php
+++ b/src/Padawan/Framework/Complete/Resolver/NodeTypeResolver.php
@@ -27,6 +27,7 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Empty_;
 use PhpParser\Node\Expr\ShellExec;
 use PhpParser\Node\Expr\Cast;
+use PhpParser\Node\Expr\ErrorSuppress;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\MagicConst;
@@ -77,7 +78,9 @@ class NodeTypeResolver
         if ($node instanceof New_ && $node->class instanceof Name) {
             return $this->useParser->getFQCN($node->class);
         }
-        if ($node instanceof Clone_) {
+        if ($node instanceof Clone_
+            || $node instanceof ErrorSuppress
+        ) {
             return $this->getType($node->expr, $index, $scope);
         }
         if ($node instanceof Closure) {

--- a/src/Padawan/Parser/MethodParser.php
+++ b/src/Padawan/Parser/MethodParser.php
@@ -62,7 +62,7 @@ class MethodParser {
                 $method->addParam($this->parseMethodArgument($child));
             }
         }
-        if (isset($node->returnType)) {
+        if (!isset($method->return) && isset($node->returnType)) {
             $method->return = $this->parseMethodReturnType($node);
         }
         return $method;

--- a/src/Padawan/Parser/MethodParser.php
+++ b/src/Padawan/Parser/MethodParser.php
@@ -7,7 +7,6 @@ use Padawan\Domain\Project\Node\MethodParam;
 use Padawan\Domain\Project\Node\Comment;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Param;
-use PhpParser\Node\Name;
 
 class MethodParser {
 
@@ -19,12 +18,14 @@ class MethodParser {
     public function __construct(
         UseParser $useParser,
         CommentParser $commentParser,
-        ParamParser $paramParser
+        ParamParser $paramParser,
+        ReturnTypeParser $returnTypeParser
     )
     {
         $this->useParser        = $useParser;
         $this->commentParser    = $commentParser;
         $this->paramParser      = $paramParser;
+        $this->returnTypeParser = $returnTypeParser;
     }
 
     /**
@@ -62,22 +63,23 @@ class MethodParser {
             }
         }
         if (isset($node->returnType)) {
-            if ($node->returnType instanceof Name) {
-                $method->return = $this->useParser->getFQCN($node->returnType);
-            } else {
-                $method->return = $node->returnType;
-            }
+            $method->return = $this->parseMethodReturnType($node);
         }
         return $method;
     }
     protected function parseMethodArgument(Param $node) {
         return $this->paramParser->parse($node);
     }
+    protected function parseMethodReturnType(ClassMethod $node) {
+        return $this->returnTypeParser->parse($node);
+    }
 
     /** @var UseParser $useParser */
     private $useParser;
-    /** @property CommentParser $commentParser */
+    /** @var CommentParser $commentParser */
     private $commentParser;
     /** @var ParamParser */
     private $paramParser;
+    /** @var ReturnTypeParser */
+    private $returnTypeParser;
 }

--- a/src/Padawan/Parser/MethodParser.php
+++ b/src/Padawan/Parser/MethodParser.php
@@ -61,6 +61,13 @@ class MethodParser {
                 $method->addParam($this->parseMethodArgument($child));
             }
         }
+        if (isset($node->returnType)) {
+            if ($node->returnType instanceof Name) {
+                $method->return = $this->useParser->getFQCN($node->returnType);
+            } else {
+                $method->return = $node->returnType;
+            }
+        }
         return $method;
     }
     protected function parseMethodArgument(Param $node) {

--- a/src/Padawan/Parser/ParamParser.php
+++ b/src/Padawan/Parser/ParamParser.php
@@ -19,15 +19,15 @@ class ParamParser {
      */
     public function parse($node) {
         $param = new MethodParam($node->name);
-        $param->setFQCN($this->createFQCN($node->type, $node->variadic));
+        $param->setFQCN($this->createFQCN($node->type, (int)$node->variadic));
         return $param;
     }
     /**
      * @param  null|Name|NullableType|Identifier|string $type
-     * @param  bool                                     $isArray
+     * @param  int                                      $dimension
      * @return null|FQCN
      */
-    protected function createFQCN($type, $isArray) {
+    protected function createFQCN($type, $dimension) {
         do {
             if ($type instanceof NullableType) {
                 $type = $type->type;
@@ -39,12 +39,12 @@ class ParamParser {
                 return null;
             }
             if (is_string($type)) {
-                return new FQCN($type, '', $isArray);
+                return new FQCN($type, '', $dimension);
             }
         } while (!$type instanceof Name);
 
         $fqcn = $this->useParser->getFQCN($type);
-        return new FQCN($fqcn->className, $fqcn->namespace, $isArray);
+        return new FQCN($fqcn->className, $fqcn->namespace, $dimension);
     }
 
     private $useParser;

--- a/src/Padawan/Parser/ReturnTypeParser.php
+++ b/src/Padawan/Parser/ReturnTypeParser.php
@@ -1,0 +1,16 @@
+<?php
+namespace Padawan\Parser;
+
+use PhpParser\Node\Stmt\ClassMethod;
+
+class ReturnTypeParser extends ParamParser
+{
+    /**
+     * @param  ClassMethod $node
+     * @return FQCN
+     */
+    public function parse($node)
+    {
+        return $this->createFQCN($node->returnType, false);
+    }
+}

--- a/src/Padawan/Parser/ReturnTypeParser.php
+++ b/src/Padawan/Parser/ReturnTypeParser.php
@@ -1,12 +1,14 @@
 <?php
 namespace Padawan\Parser;
 
+use Padawan\Domain\Project\FQCN;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
 
 class ReturnTypeParser extends ParamParser
 {
     /**
-     * @param  ClassMethod $node
+     * @param  ClassMethod|Function_ $node
      * @return FQCN
      */
     public function parse($node)

--- a/src/Padawan/Parser/ReturnTypeParser.php
+++ b/src/Padawan/Parser/ReturnTypeParser.php
@@ -11,6 +11,6 @@ class ReturnTypeParser extends ParamParser
      */
     public function parse($node)
     {
-        return $this->createFQCN($node->returnType, false);
+        return $this->createFQCN($node->returnType, 0);
     }
 }

--- a/src/Padawan/Parser/Transformer/FunctionTransformer.php
+++ b/src/Padawan/Parser/Transformer/FunctionTransformer.php
@@ -8,6 +8,7 @@ use Padawan\Domain\Project\Node\FunctionData;
 use Padawan\Domain\Project\Node\MethodParam;
 use Padawan\Parser\CommentParser;
 use Padawan\Parser\ParamParser;
+use Padawan\Parser\ReturnTypeParser;
 use Padawan\Parser\UseParser;
 
 class FunctionTransformer
@@ -15,10 +16,12 @@ class FunctionTransformer
     public function __construct(
         CommentParser $commentParser,
         ParamParser $paramParser,
+        ReturnTypeParser $returnTypeParser,
         UseParser $useParser
     ) {
         $this->commentParser = $commentParser;
         $this->paramParser = $paramParser;
+        $this->returnTypeParser = $returnTypeParser;
         $this->useParser = $useParser;
     }
     public function tranform(Function_ $node)
@@ -31,6 +34,9 @@ class FunctionTransformer
             if ($child instanceof Param) {
                 $function->addArgument($this->tranformArgument($child));
             }
+        }
+        if (!isset($function->return) && isset($node->returnType)) {
+            $function->return = $this->tranformReturnType($node);
         }
         return $function;
     }
@@ -57,6 +63,10 @@ class FunctionTransformer
     protected function tranformArgument(Param $node)
     {
         return $this->paramParser->parse($node);
+    }
+    protected function tranformReturnType(Function_ $node)
+    {
+        return $this->returnTypeParser->parse($node);
     }
 
     private $paramParser;

--- a/src/Padawan/Parser/UseParser.php
+++ b/src/Padawan/Parser/UseParser.php
@@ -2,6 +2,7 @@
 
 namespace Padawan\Parser;
 
+use Padawan\Domain\Project\FQN;
 use Padawan\Domain\Project\FQCN;
 use Padawan\Domain\Project\Node\Uses;
 use PhpParser\Node\Name;
@@ -44,7 +45,10 @@ class UseParser {
         }
         $fqcn = $this->uses->find($node->getFirst());
         if($fqcn){
-            return $fqcn;
+            if ($node->isUnqualified()) {
+                return $fqcn;
+            }
+            return $fqcn->join(new FQN($node->slice(1)->toString()));
         }
         return $this->createFQCN($node->toString());
     }

--- a/src/Padawan/Parser/UseParser.php
+++ b/src/Padawan/Parser/UseParser.php
@@ -59,17 +59,17 @@ class UseParser {
         }
         $parts = explode('\\', $fqcn);
         $name = array_pop($parts);
-        $regex = '/(\w+)(\\[\\])?/';
+        $regex = '/(\w+)((?:\[\])*)/';
         preg_match($regex, $name, $matches);
         if(count($matches) === 0){
             throw new \Exception("Could not parse FQCN for empty class name: " . $fqcn);
         }
         $name = $matches[1];
-        $isArray = count($matches) === 3 && $matches[2] = '[]';
+        $dimension = isset($matches[2]) ? strlen($matches[2]) / 2 : 0;
         return new FQCN(
             $name,
             $parts,
-            $isArray
+            $dimension
         );
     }
     public function getUses() {

--- a/src/Padawan/Parser/Walker/ScopeWalker.php
+++ b/src/Padawan/Parser/Walker/ScopeWalker.php
@@ -273,7 +273,7 @@ class ScopeWalker extends NodeVisitorAbstract implements WalkerInterface
      * @param List_|Array_    $list
      * @param Assign|Foreach_ $parent
      */
-    public function addListToScope($list, $parent)
+    public function addListToScope($list, $parent, $level = 1)
     {
         $comment = $this->commentParser->parse($parent->getAttribute('comments'));
         if ($parent->expr instanceof NodeVar && $comment->getVar($parent->expr->name)) {
@@ -291,9 +291,16 @@ class ScopeWalker extends NodeVisitorAbstract implements WalkerInterface
         }
 
         foreach ($list->items as $item) {
+            if (!isset($item->value)) {
+                continue;
+            }
+            if ($item->value instanceof List_ || $item->value instanceof Array_) {
+                $this->addListToScope($item->value, $parent, $level + 1);
+                continue;
+            }
             if ($item->value instanceof NodeVar) {
                 $var = new Variable($item->value->name);
-                $var->setType(new FQCN($type->className, $type->namespace, $type->getDimension() - 1));
+                $var->setType(new FQCN($type->className, $type->namespace, $type->getDimension() - $level));
                 $this->scope->addVar($var);
             }
         }

--- a/src/Padawan/Parser/Walker/ScopeWalker.php
+++ b/src/Padawan/Parser/Walker/ScopeWalker.php
@@ -188,11 +188,14 @@ class ScopeWalker extends NodeVisitorAbstract implements WalkerInterface
         }
 
         $current = $this->scope->getVar($var->getName());
-        if (!isset($type) || ($current && $current->getType())) {
+        if (!isset($type) && $current && $current->getType()) {
             return;
         }
 
-        $var->setType($type);
+        if (isset($type)) {
+            $var->setType($type);
+        }
+
         $this->scope->addVar($var);
     }
     public function parseUse(Use_ $node, $fqcn, $file)

--- a/src/Padawan/Parser/Walker/ScopeWalker.php
+++ b/src/Padawan/Parser/Walker/ScopeWalker.php
@@ -119,7 +119,12 @@ class ScopeWalker extends NodeVisitorAbstract implements WalkerInterface
     public function createScopeFromClosure(Closure $node)
     {
         $scope = $this->scope;
-        $this->scope = new ClosureScope($scope);
+        $classData = null;
+        if (!$node->static && $scope instanceof MethodScope) {
+            $index = $this->getIndex();
+            $classData = $index->findClassByFQCN($scope->getClass()->fqcn);
+        }
+        $this->scope = new ClosureScope($scope, $classData);
         foreach ($node->params as $param) {
             $this->scope->addVar(
                 $this->paramParser->parse($param)

--- a/src/Padawan/Parser/Walker/ScopeWalker.php
+++ b/src/Padawan/Parser/Walker/ScopeWalker.php
@@ -179,7 +179,7 @@ class ScopeWalker extends NodeVisitorAbstract implements WalkerInterface
             $type = $this->useParser->getFQCN($node->types[0]);
         } elseif ($comment->getVar($var->getName())) {
             $type = $comment->getVar($var->getName())->getType();
-        } else {
+        } elseif (isset($node->expr)) {
             $type = $this->typeResolver->getType(
                 $node->expr,
                 $this->getIndex(),
@@ -188,7 +188,7 @@ class ScopeWalker extends NodeVisitorAbstract implements WalkerInterface
         }
 
         $current = $this->scope->getVar($var->getName());
-        if (!$type && $current && $current->getType()) {
+        if (!isset($type) || ($current && $current->getType())) {
             return;
         }
 


### PR DESCRIPTION
This PR aims padawan to have better type parsing.

## Fix non-static Closure to have $this variable

```php
<?php
class Foo
{
    public function test()
    {
        $x = function () {
            // Complete $this here with class Foo
        };
    }
}
```

## Add support for native method return types (PHP >= 7)

```php
class Foo
{
    public function time(): \DateTime
    {
        return new \DateTime();
    }

    public function test()
    {
        // Use return type of Foo::time() so that it can be used in completion
        $this->test()->getTimestamp();
    }
}
```

## Fix to parse more assignments

```php
// Use return type of functions
$f = date_create();

// Use result of casts
$c = (bool)0;
$c = (array)0;
$c = (object)[];
$c = (double)0;
$c = (int)0;
$c = (string)0;

// Use types of literal values
$l = true;
$l = [];
$l = array();
$l = 1.0;
$l = 1;
$l = 'str';
$l = "concat {$l}";
$l = `ls`;

// Use operators that return bool or int
$b = ![];
$b = isset($b);
$b = empty($b);
$i = print 'hello';

// Use magic constants
$m = __FILE__;
$m = __LINE__;
```

## Fix UseParser not to return incorrect FQCN

In some cases, `UseParser` returns incorrect FQCN, so it fixes.

```php
<?php
use GuzzleHttp\Promise;

// $p should be GuzzleHttp\Promise\PromiseInterface
// but the actual behavior returned GuzzleHttp\Promise
function test(Promise\PromiseInterface $p) {}
```

## Fix to parse non-assigned variables including try-catch

```php
<?php
// This variable was not caught
$foo;

try {
} catch (\RuntimeException $e) {
} catch (\Exception $e) {
    // This $e is now able to be completed with types
    echo $e->getMessage();
}
```