### PR TITLE
Add and fix scope related behaviors

### DIFF
--- a/features/class-scope-completion.feature
+++ b/features/class-scope-completion.feature
@@ -327,3 +327,60 @@ Feature: Class Scope
             | class          |
             | $someStaticApi |
             | staticMethod   |
+
+    Scenario: Accessing only public/protected methods and properties for parent
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeOtherClass
+        {
+            public function publicApi()
+            {
+
+            }
+            protected function protectedMethod()
+            {
+
+            }
+            private function privateMethod()
+            {
+
+            }
+            public static function publicStaticApi()
+            {
+
+            }
+            protected static function protectedStaticMethod()
+            {
+
+            }
+            private static function privateStaticMethod()
+            {
+
+            }
+            public $aPublicProperty;
+            protected $aProtectedProperty;
+            private $aPrivateProperty;
+            public $aPublicStaticProperty;
+            protected $aProtectedStaticProperty;
+            private $aPrivateStaticProperty;
+        }
+
+        class SomeClass extends SomeOtherClass
+        {
+            public function method()
+            {
+
+            }
+        }
+        """
+        When I type "parent::" on the 41 line
+        And I ask for completion
+        Then I should get:
+            | Name                  |
+            | class                 |
+            | protectedMethod       |
+            | protectedStaticMethod |
+            | publicApi             |
+            | publicStaticApi       |

--- a/features/class-scope-completion.feature
+++ b/features/class-scope-completion.feature
@@ -204,3 +204,39 @@ Feature: Class Scope
             | method1 |
             | method2 |
             | someApi |
+
+    Scenario: Accessing only public methods and properties for return static
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeClass
+        {
+            /**
+             * @return static
+             */
+            public static function method1()
+            {
+
+            }
+            public static function method2()
+            {
+
+            }
+            private static function somePrivateMethod()
+            {
+
+            }
+            private static $someDep;
+            public static $someApi;
+        }
+
+        """
+        When I type "SomeClass::" on the 23 line
+        And I ask for completion
+        Then I should get:
+            | Name     |
+            | class    |
+            | method1  |
+            | method2  |
+            | $someApi |

--- a/features/class-scope-completion.feature
+++ b/features/class-scope-completion.feature
@@ -3,7 +3,7 @@ Feature: Class Scope
     I want to have different visibility scopes in class and out of class
     So that I can see private methods when getting completions for $this
 
-    Scenario: Gettings all methods and properties for $this
+    Scenario: Getting all methods and properties for $this
         Given there is a file with:
         """
         <?php
@@ -119,7 +119,7 @@ Feature: Class Scope
             | methodOfOtherClass |
             | otherMethodOfOtherClass |
 
-    Scenario: Gettings all methods and properties for $this with @return $this
+    Scenario: Getting all methods and properties for $this with @return $this
         Given there is a file with:
         """
         <?php
@@ -148,10 +148,12 @@ Feature: Class Scope
         When I type "$this->method1()->" on the 18 line
         And I ask for completion
         Then I should get:
-            | Name |
-            | method1 |
-            | method2 |
-            | someApi |
+            | Name              |
+            | method1           |
+            | method2           |
+            | someApi           |
+            | someDep           |
+            | somePrivateMethod |
 
     Scenario: Accessing only public methods and properties for return $this
         Given there is a file with:
@@ -200,12 +202,12 @@ Feature: Class Scope
         And I type "$a->method1()->" on the 16 line
         And I ask for completion
         Then I should get:
-            | Name |
+            | Name    |
             | method1 |
             | method2 |
             | someApi |
 
-    Scenario: Accessing only public methods and properties for return static
+    Scenario: Getting all static methods and properties by :: with @return static
         Given there is a file with:
         """
         <?php
@@ -215,28 +217,113 @@ Feature: Class Scope
             /**
              * @return static
              */
-            public static function method1()
+            public static function staticMethod()
             {
 
             }
-            public static function method2()
+            private static function somePrivateStaticMethod()
             {
 
             }
-            private static function somePrivateMethod()
+            public function method()
             {
 
             }
-            private static $someDep;
-            public static $someApi;
+            private function somePrivateMethod()
+            {
+
+            }
+            private static $someStaticDep;
+            public static $someStaticApi;
+            private $someDep;
+            public $someApi;
+        }
+        """
+        When I type "static::staticMethod()::" on the 18 line
+        And I ask for completion
+        Then I should get:
+            | Name                    |
+            | class                   |
+            | somePrivateStaticMethod |
+            | $someStaticApi          |
+            | $someStaticDep          |
+            | staticMethod            |
+
+    Scenario: Getting all non-static methods and properties by -> with @return static
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeClass
+        {
+            /**
+             * @return static
+             */
+            public static function staticMethod()
+            {
+
+            }
+            private static function somePrivateStaticMethod()
+            {
+
+            }
+            public function method()
+            {
+
+            }
+            private function somePrivateMethod()
+            {
+
+            }
+            private static $someStaticDep;
+            public static $someStaticApi;
+            private $someDep;
+            public $someApi;
+        }
+        """
+        When I type "static::staticMethod()->" on the 18 line
+        And I ask for completion
+        Then I should get:
+            | Name              |
+            | method            |
+            | someApi           |
+            | someDep           |
+            | somePrivateMethod |
+
+    Scenario: Accessing only public static methods and properties
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeClass
+        {
+            public static function staticMethod()
+            {
+
+            }
+            private static function somePrivateStaticMethod()
+            {
+
+            }
+            public function method()
+            {
+
+            }
+            private function somePrivateMethod()
+            {
+
+            }
+            private static $someStaticDep;
+            public static $someStaticApi;
+            private $someDep;
+            public $someApi;
         }
 
         """
-        When I type "SomeClass::" on the 23 line
+        When I type "SomeClass::" on the 26 line
         And I ask for completion
         Then I should get:
-            | Name     |
-            | class    |
-            | method1  |
-            | method2  |
-            | $someApi |
+            | Name           |
+            | class          |
+            | $someStaticApi |
+            | staticMethod   |

--- a/features/names-completion.feature
+++ b/features/names-completion.feature
@@ -1,6 +1,6 @@
 Feature: Names Completion
     As a user
-    I want to have all names(functions, classes, interfaces) when typing a T_STRING
+    I want to have all names (functions, classes, interfaces, namespaces) when typing a T_STRING
     In order to have access to built-in and project names
 
     Scenario: Getting all global functions with prefix
@@ -47,3 +47,86 @@ Feature: Names Completion
             | Menu |
             | array_pop_custom |
             | array_pop |
+
+    Scenario: Getting all classes with prefix by extends
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeClass
+        {
+        }
+
+        class SomeOtherClass {}
+        """
+        When I type " extends SomeO" on the 3 line
+        And I ask for completion
+        Then I should get:
+            | Menu           |
+            | SomeOtherClass |
+
+    Scenario: Getting all interfaces with prefix by implements
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeClass
+        {
+        }
+
+        interface SomeInterface {}
+        """
+        When I type " implements SomeI" on the 3 line
+        And I ask for completion
+        Then I should get:
+            | Menu          |
+            | SomeInterface |
+
+    Scenario: Getting all classes with prefix by new
+        Given there is a file with:
+        """
+        <?php
+
+        class SomeClass {}
+        """
+        When I type "new Some" on the 4 line
+        And I ask for completion
+        Then I should get:
+            | Menu      |
+            | SomeClass |
+
+    Scenario: Getting all namespaces with prefix by namespace
+        Given there is a file with:
+        """
+        <?php
+
+        namespace Test\Test1
+        {
+            class SomeClass {}
+        }
+
+        namespace Test\Test2 {}
+        """
+        When I type "namespace Test" on the 9 line
+        And I ask for completion
+        Then I should get:
+            | Menu       |
+            | Test\Test1 |
+
+    Scenario: Getting all namespaces with prefix by use
+        Given there is a file with:
+        """
+        <?php
+
+        namespace Test\Test1
+        {
+            class SomeClass {}
+        }
+
+        namespace Test\Test2 {}
+        """
+        When I type "use Test" on the 9 line
+        And I ask for completion
+        Then I should get:
+            | Menu                 |
+            | Test\Test1\SomeClass |

--- a/src/Padawan/Domain/Completer/ClassNameCompleter.php
+++ b/src/Padawan/Domain/Completer/ClassNameCompleter.php
@@ -10,17 +10,15 @@ class ClassNameCompleter implements CompleterInterface
 {
     public function getEntries(Project $project, Context $context) {
         $entries = [];
-        $postfix = trim("");
+        $postfix = trim($context->getData());
+        $uses = $context->getScope()->getUses();
         foreach ($project->getIndex()->getClasses() as $fqcn => $class) {
+            $fqcn = $uses ? $uses->findAlias($class->fqcn) : $class->fqcn;
             if (!empty($postfix) && strpos($fqcn, $postfix) === false) {
                 continue;
             }
-            $fqcn = $context->getScope()->getUses()->findAlias($class->fqcn);
             $complete = str_replace($postfix, "", $fqcn);
-            $entries[] = new Entry(
-                $complete, '', '',
-                $fqcn
-            );
+            $entries[] = new Entry($complete, '', '', $fqcn);
         }
         return $entries;
     }

--- a/src/Padawan/Domain/Completer/InterfaceNameCompleter.php
+++ b/src/Padawan/Domain/Completer/InterfaceNameCompleter.php
@@ -10,9 +10,15 @@ class InterfaceNameCompleter implements CompleterInterface
 {
     public function getEntries(Project $project, Context $context) {
         $entries = [];
+        $postfix = trim($context->getData());
+        $uses = $context->getScope()->getUses();
         foreach ($project->getIndex()->getInterfaces() as $interface) {
-            $fqcn = $interface->fqcn;
-            $entries[] = new Entry($fqcn->toString());
+            $fqcn = $uses ? $uses->findAlias($interface->fqcn) : $interface->fqcn;
+            if (!empty($postfix) && strpos($fqcn, $postfix) === false) {
+                continue;
+            }
+            $complete = str_replace($postfix, "", $fqcn);
+            $entries[] = new Entry($complete, '', '', $fqcn);
         }
         return $entries;
     }

--- a/src/Padawan/Domain/Completion/Context.php
+++ b/src/Padawan/Domain/Completion/Context.php
@@ -40,15 +40,19 @@ class Context
             $this->addType(self::T_CLASS_STATIC);
         } elseif ($token->isNamespaceOperator()) {
             $this->addType(self::T_NAMESPACE);
+            $this->setData($token->getSymbol());
         } elseif ($token->isUseOperator()) {
             $this->addType(self::T_USE);
-            $this->addType(self::T_CLASSNAME);
+            $this->setData($token->getSymbol());
         } elseif ($token->isNewOperator()) {
             $this->addType(self::T_CLASSNAME);
+            $this->setData($token->getSymbol());
         } elseif ($token->isExtendsOperator()) {
             $this->addType(self::T_CLASSNAME);
+            $this->setData($token->getSymbol());
         } elseif ($token->isImplementsOperator()) {
             $this->addType(self::T_INTERFACENAME);
+            $this->setData($token->getSymbol());
         } elseif ($token->isMethodCall()) {
             $this->addType(self::T_METHOD_CALL);
         } elseif ($token->isString()) {

--- a/src/Padawan/Domain/Project/Node/ClassData.php
+++ b/src/Padawan/Domain/Project/Node/ClassData.php
@@ -88,7 +88,7 @@ class ClassData
     public function addMethod(MethodData $method)
     {
         if ($method->return instanceof FQCN) {
-            if ($method->return->getLast() === 'this') {
+            if (in_array($method->return->getLast(), ['this', 'self', 'static'], true)) {
                 $method->return = $this->fqcn;
             }
         }

--- a/src/Padawan/Domain/Scope.php
+++ b/src/Padawan/Domain/Scope.php
@@ -15,6 +15,8 @@ interface Scope
     public function getVar($varName);
     public function addVar(Variable $var);
     /** @return FQCN */
+    public function getFQCN();
+    /** @return FQCN */
     public function getNamespace();
     /** @return Uses */
     public function getUses();

--- a/src/Padawan/Domain/Scope/AbstractChildScope.php
+++ b/src/Padawan/Domain/Scope/AbstractChildScope.php
@@ -17,6 +17,10 @@ abstract class AbstractChildScope extends AbstractScope
     {
         return $this->parent;
     }
+    public function getFQCN()
+    {
+        return $this->parent->getFQCN();
+    }
     public function getNamespace()
     {
         return $this->parent->getNamespace();

--- a/src/Padawan/Domain/Scope/FileScope.php
+++ b/src/Padawan/Domain/Scope/FileScope.php
@@ -22,11 +22,11 @@ class FileScope extends AbstractScope
     }
     public function getFQCN()
     {
-        return $this->uses->getFQCN();
+        return $this->uses ? $this->uses->getFQCN() : null;
     }
     public function getNamespace()
     {
-        return $this->uses->getFQCN();
+        return $this->uses ? $this->uses->getFQCN() : null;
     }
     public function getUses()
     {

--- a/src/Padawan/Domain/Scope/FileScope.php
+++ b/src/Padawan/Domain/Scope/FileScope.php
@@ -20,6 +20,10 @@ class FileScope extends AbstractScope
     {
         $this->uses = $uses;
     }
+    public function getFQCN()
+    {
+        return $this->uses->getFQCN();
+    }
     public function getNamespace()
     {
         return $this->uses->getFQCN();

--- a/src/Padawan/Framework/Complete/Resolver/ContextResolver.php
+++ b/src/Padawan/Framework/Complete/Resolver/ContextResolver.php
@@ -72,21 +72,13 @@ class ContextResolver
             } else {
                 $workingNode = $nodes;
             }
-            $isThis = false;
-            if ($workingNode instanceof Variable && $workingNode->name === 'this') {
-                $isThis = true;
-            }
-            if ($workingNode instanceof Name) {
-                $nodeFQCN = $this->useParser->getFQCN($workingNode);
-                if ($scope->getFQCN() instanceof FQCN
-                    && $nodeFQCN->toString() === $scope->getFQCN()->toString()
-                ) {
-                    $isThis = true;
-                }
-            }
             $types = $this->typeResolver->getChainType($workingNode, $index, $scope);
+            $workingNodeType = array_pop($types);
+            $isThis = $scope->getFQCN() instanceof FQCN
+                && $workingNodeType instanceof FQCN
+                && $workingNodeType->toString() === $scope->getFQCN()->toString();
             $context->setData([
-                array_pop($types),
+                $workingNodeType,
                 $isThis,
                 $types,
                 $workingNode

--- a/src/Padawan/Framework/Complete/Resolver/ContextResolver.php
+++ b/src/Padawan/Framework/Complete/Resolver/ContextResolver.php
@@ -77,9 +77,12 @@ class ContextResolver
             $isThis = $scope->getFQCN() instanceof FQCN
                 && $workingNodeType instanceof FQCN
                 && $workingNodeType->toString() === $scope->getFQCN()->toString();
+            $isParent = $workingNode instanceof Name
+                && $workingNode->getFirst() === 'parent';
             $context->setData([
                 $workingNodeType,
                 $isThis,
+                $isParent,
                 $types,
                 $workingNode
             ]);


### PR DESCRIPTION
## Fix a bug where static class completion did not work out of class (d07509d978d8fa2909856b3c519853fdf122ae98)

Padawan had crashed outside of class context because `Padawan\Domain\Scope\FileScope` did not implement `getFQCN()` method.

## Support static/self as method return type (74c4d725b715e12b12e8ea6f4d1a5a4fb79e4250)<br>Fix ContextResolver to properly get visibility (786e4c8aa06ddc967bf8e55b896e9928946dd6c9)

The `ContextResolver` did not understand `$this` context properly and this commit fixes how `$this` is constructed. In PHP, `private` means a method/property can be accessed only from the same class, **NOT** only from the same instance.

```php
<?php

class SomeClass
{
    /**
     * @return static
     */
    private static function method1()
    {
        return new static();
    }

    private function method2()
    {
        // This will be now completed.
        static::method1()::method1()->method2();
    }
}
```

## Fix bugs where class/interface/namespace completions ignored context (b9ff92c392bbad6410ba0b411e79778805040b90)

Completer could not get the current input because `Padawan\Domain\Completion\Context` did not set symbol data inside `namespace`, `use`, `new`, `extends` and `implements`.

## Add support for parent:: completion (1443b92b895958bb29f9b0cd007323e303b359b9)

`parent::` is considered `StaticCompleter` but it works slightly different from usual static operator. If the class that refers to is different from the current context, the completion will be limited to `public` spec; otherwise, the completion could be either `protected` or `private`. And the level of accessibility is complicated as follows:

| Context        | Member Methods | Static Methods | Member Properties | Static Properties |
|:---------------|:---------------|:---------------|:------------------|:------------------|
| `parent::`     | protected      | protected      | N/A               | N/A               |
| `static::`     | N/A            | private        | N/A               | private           |
| `self::`       | N/A            | private        | N/A               | private           |
| `SameClass::`  | N/A            | private        | N/A               | private           |
| `OtherClass::` | N/A            | public         | N/A               | public            |

Each fix is tested with feature attached with commit.